### PR TITLE
Allow for config to be a Map instead of a string

### DIFF
--- a/app_config/app_config.py
+++ b/app_config/app_config.py
@@ -71,9 +71,12 @@ class AppConfig(Mapping):
         try:
             item = self._table.get_item(hash_key=section_name, range_key=environment)
             if item:
-                dict_ = json.loads(item.get("config", "{}"))
-                assert (isinstance(dict_, dict))
-                return_dict = dict_
+                if item.get("config", None) and isinstance(item.get("config"), dict):
+                    return item.get("config")
+                else:
+                    dict_ = json.loads(item.get("config", "{}"))
+                    assert (isinstance(dict_, dict))
+                    return_dict = dict_
         except BotoClientError as e:
             if e.reason == "Key does not exist.":
                 logger.warning(e.message)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def readme():
 
 
 setup(name="app-config",
-      version="1.0.1",
+      version="1.0.2",
       description="GBDX App Config",
       long_description=readme(),
       keywords=['config', 'gbdx'],


### PR DESCRIPTION
Added a condition to check if the item is a dict, when fetching the config. This allows for config to be a Map in DynamoDB, which is easier to edit. 

@Brett55 you seem to be the main contributor. Could you review and merge if acceptable?